### PR TITLE
Fix Errors

### DIFF
--- a/ExtremeSkins.Generator.Core/TranslationExporter.cs
+++ b/ExtremeSkins.Generator.Core/TranslationExporter.cs
@@ -45,7 +45,7 @@ public sealed class TranslationExporter : IExporter
         {SupportedLangs.Italian   , ""},
         {SupportedLangs.Japanese  , "ja-JP"},
         {SupportedLangs.Spanish   , ""},
-        {SupportedLangs.SChinese  , ""},
+        {SupportedLangs.SChinese  , "zh-CN"},
         {SupportedLangs.TChinese  , ""},
         {SupportedLangs.Irish     , ""},
     };


### PR DESCRIPTION
When outputting, the simplified Chinese name is not displayed in "translation. csv".